### PR TITLE
Class initializer generation

### DIFF
--- a/Sources/GRDBMacros/Macros.swift
+++ b/Sources/GRDBMacros/Macros.swift
@@ -13,6 +13,10 @@ import GRDB
   conformances: FetchableRecord, PersistableRecord,
   names: named(init(row:)), named(encode(to:)), named(Columns), named(databaseSelection)
 )
+@attached(
+  member,
+  names: named(init(row:))
+)
 public macro DatabaseRecord() = #externalMacro(module: "GRDBMacrosPlugin", type: "DatabaseRecordMacro")
 
 @attached(peer)

--- a/Sources/GRDBMacrosPlugin/DatabaseRecordMacro.swift
+++ b/Sources/GRDBMacrosPlugin/DatabaseRecordMacro.swift
@@ -164,7 +164,7 @@ extension DatabaseRecordMacro: MemberMacro {
 
     return [
         """
-        \(raw: access)init(row: \(raw: qualified("Row"))) {
+        \(raw: access)required init(row: \(raw: qualified("Row"))) {
         \(raw: args.map(\.fetchableDecl.trimmedDescription).joined(separator: "\n"))
         }
         """

--- a/Tests/GRDBMacrosTests/GRDBMacrosTests.swift
+++ b/Tests/GRDBMacrosTests/GRDBMacrosTests.swift
@@ -135,4 +135,52 @@ final class GRDBMacrosTests: XCTestCase {
       """
     }
   }
+
+  func testMacroForClass() throws {
+    assertMacro {
+      """
+      @DatabaseRecord
+      class Author {
+        var id: Int64?
+        var countryCode: String?
+      }
+      """
+    } expansion: {
+      """
+      class Author {
+        var id: Int64?
+        var countryCode: String?
+
+        init(row: GRDB.Row) {
+           self.id = row[Columns.id]
+           self.countryCode = row[Columns.countryCode]
+        }
+      }
+
+      extension Author: GRDB.FetchableRecord {
+      }
+
+      extension Author: GRDB.PersistableRecord {
+        func encode(to container: inout GRDB.PersistenceContainer) throws {
+           container[Columns.id] = id
+           container[Columns.countryCode] = countryCode
+        }
+      }
+
+      extension Author {
+        enum Columns {
+          static let id = GRDB.Column("id")
+          static let countryCode = GRDB.Column("countryCode")
+        }
+      }
+
+      extension Author {
+        static let databaseSelection: [any GRDB.SQLSelectable] = [
+          Columns.id,
+          Columns.countryCode
+        ]
+      }
+      """
+    }
+  }
 }

--- a/Tests/GRDBMacrosTests/GRDBMacrosTests.swift
+++ b/Tests/GRDBMacrosTests/GRDBMacrosTests.swift
@@ -151,7 +151,7 @@ final class GRDBMacrosTests: XCTestCase {
         var id: Int64?
         var countryCode: String?
 
-        init(row: GRDB.Row) {
+        required init(row: GRDB.Row) {
            self.id = row[Columns.id]
            self.countryCode = row[Columns.countryCode]
         }


### PR DESCRIPTION
This PR fixes the generation of the row initializer (from GRDB.FetchableRecord) for classes.

The initializer needs to be added to the class body, since extensions can only provide convenience initializers